### PR TITLE
Add FindAeroDyn.cmake

### DIFF
--- a/Modules/FedemConfig.cmake
+++ b/Modules/FedemConfig.cmake
@@ -20,6 +20,7 @@ endif ( WIN32 OR WIN64 )
 
 option ( FTENV_VERBOSE "Enable more output during Configure" OFF )
 option ( FTENV_WARNINGS "Enable extra compiler warnings" ON )
+option ( BUILD_TESTS "Build and execute unit/regression tests" ON )
 
 option ( PLATFORM_BITSIZE_IS_64_BIT "Use default bitsize of 64 bit" ON )
 mark_as_advanced ( PLATFORM_BITSIZE_IS_64_BIT )

--- a/Modules/FindAeroDyn.cmake
+++ b/Modules/FindAeroDyn.cmake
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: 2023 SAP SE
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# This file is part of FEDEM - https://openfedem.org
+
+# This Find rule sets up for building the FEDEM dynamics solver with
+# AeroDyn v13 from NREL (https://www.nrel.gov/wind/nwtc/aerodyn.html).
+# The AeroDyn module is not part of the Open FEDEM project itself.
+# Please contact developers@openfedem.org if you want to try out
+# the wind turbine simulation capabilities with FEDEM and AeroDyn.
+
+unset ( AeroDyn_INCLUDE CACHE )
+unset ( AeroDyn_LIBRARY CACHE )
+unset ( AeroDyn_DLL CACHE )
+unset ( TURBSIM CACHE )
+
+find_path ( AeroDyn_INCLUDE
+            NAMES aerodyn.mod
+            PATHS C:/NREL/include $ENV{NREL_HOME}/include
+            ${HOME}/.local/include /usr/local/include
+          )
+
+if ( AeroDyn_INCLUDE )
+  message ( STATUS "Found AeroDyn: ${AeroDyn_INCLUDE}" )
+  find_library ( AeroDyn_LIBRARY
+                 NAMES AeroDyn
+                 PATHS C:/NREL/lib $ENV{NREL_HOME}/lib
+                 ${HOME}/.local/lib /usr/local/lib
+               )
+endif ( AeroDyn_INCLUDE )
+
+if ( AeroDyn_LIBRARY )
+  if ( WIN )
+    find_file ( AeroDyn_DLL
+                NAMES AeroDyn.dll
+                PATHS C:/NREL/bin $ENV{NREL_HOME}/bin
+                ${HOME}/.local/bin /usr/local/bin
+                NO_DEFAULT_PATH
+              )
+    message ( STATUS "Found AeroDyn: ${AeroDyn_LIBRARY} ${AeroDyn_DLL}" )
+  else ( WIN )
+    message ( STATUS "Found AeroDyn: ${AeroDyn_LIBRARY}" )
+  endif ( WIN )
+  include_directories ( ${AeroDyn_INCLUDE} )
+  string ( APPEND CMAKE_Fortran_FLAGS " -DFT_HAS_AERODYN=13" )
+  find_program ( TURBSIM
+                 NAMES TurbSim
+                 PATHS C:/NREL/bin $ENV{NREL_HOME}/bin
+                 ${HOME}/.local/bin /usr/local/bin
+                 NO_DEFAULT_PATH
+               )
+  if ( TURBSIM )
+    message ( STATUS "Found TurbSim: ${TURBSIM}" )
+  endif ( TURBSIM )
+else ( AeroDyn_LIBRARY )
+  message ( WARNING "Did NOT find AeroDyn library, configuring without it." )
+endif ( AeroDyn_LIBRARY )

--- a/Modules/FindVTFAPI.cmake
+++ b/Modules/FindVTFAPI.cmake
@@ -8,8 +8,8 @@
 # library for writing VTF files for visualization in GLview.
 # Although it is not an open source module, we maintain the
 # coupling to it through this Find rule.
-# If it happens you should have a need for it, please contact
-# someone in the OPEN Fedem team (https://openfedem.org/about/)
+# If you should have a need for it, please contact someone in
+# the Open Fedem team (https://openfedem.org/developer_area/)
 # and we'll see what we can do about it.
 
 unset ( VTF_INCLUDE CACHE )
@@ -17,16 +17,15 @@ unset ( VTF_LIBRARY CACHE )
 
 find_path ( VTF_INCLUDE
             NAMES VTFAPI.h
-            PATHS C:/VTFAPI/include /usr/local/include
-           )
+            PATHS C:/VTFAPI/include
+            ${HOME}/.local/include /usr/local/include
+          )
 
 if ( VTF_INCLUDE )
   message ( STATUS "Found VTF API: ${VTF_INCLUDE}" )
-  include_directories ( ${VTF_INCLUDE} )
-
   find_library ( VTF_LIBRARY
                  NAMES VTFExpressAPI
-                 PATHS C:/VTFAPI/lib /usr/local/lib
+                 PATHS C:/VTFAPI/lib ${HOME}/.local/lib /usr/local/lib
                )
 endif ( VTF_INCLUDE )
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ and what they do:
   [lcov](https://github.com/linux-test-project/lcov), and
   [gcovr](https://gcovr.com/en/stable/) (on Linux only).
 
+In addition, some files named `Find<module>.cmake` are present.
+They define find-rules to be used by the cmake command
+[find_package()](https://cmake.org/cmake/help/latest/command/find_package.html),
+i.e., `find_package(<module>)` to locate and set up for build with the package `<module>`.
+
 ## Contributing
 
 This project is open to feature requests, suggestions, bug reports, etc.,


### PR DESCRIPTION
Required for building the dynamics solver with externally build AeroDyn and TurbSim modules.
Also adding a option (default ON) for building and executing the unit and regression tests.