### PR TITLE
Set policy CMP0144 to OLD to suppress warning in cmake 3.27 and later

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2023 SAP SE
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# This file is part of FEDEM - https://openfedem.org
+
+name: Unit testing
+
+on:
+  pull_request:
+    branches:
+      - main
+
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    name: Build and execute unit tests
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install googletest
+        uses: Bacondish2023/setup-googletest@v1
+
+      - name: Check out source repository
+        uses: actions/checkout@v3
+
+      - name: Configure cmake
+        run: GTEST_ROOT=/usr/local cmake -B ./build -S ./test -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build and execute tests
+        run: cmake --build ./build --target check

--- a/Modules/GTest.cmake
+++ b/Modules/GTest.cmake
@@ -15,6 +15,9 @@ endif ( POLICY CMP0057 )
 if ( POLICY CMP0074 )
   cmake_policy ( SET CMP0074 NEW ) # using <package>_ROOT variables
 endif ( POLICY CMP0074 )
+if ( POLICY CMP0144 )
+  cmake_policy ( SET CMP0144 OLD ) # ignoring <PACKAGE>_ROOT variables
+endif ( POLICY CMP0144 )
 
 # Find the google unit testing framework
 find_path ( GTEST_ROOT gtest.h PATHS "$ENV{GTEST_ROOT}/include/gtest" )

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 --->
 
 [![REUSE status](https://api.reuse.software/badge/github.com/openfedem/cmake-modules)](https://api.reuse.software/info/github.com/openfedem/cmake-modules)
+[![Unit testing](https://github.com/openfedem/cmake-modules/actions/workflows/run-test.yml/badge.svg)](https://github.com/openfedem/cmake-modules/actions/workflows/run-test.yml)
 
 # FEDEM cmake modules
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2023 SAP SE
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# This file is part of FEDEM - https://openfedem.org
+
+cmake_minimum_required ( VERSION 2.8...3.5 )
+
+# Project setup
+
+project ( cmake-test CXX )
+
+message ( STATUS "Generating build project for ${PROJECT_SOURCE_DIR}" )
+find_path ( _MODULES FedemConfig.cmake
+            PATHS $ENV{CMAKE_MODULES} ../Modules )
+if ( _MODULES )
+  message ( STATUS "NOTE : Using ${_MODULES}" )
+  list ( APPEND CMAKE_MODULE_PATH ${_MODULES} )
+else ( _MODULES )
+  message ( STATUS "ERROR : Missing path to FedemConfig.cmake" )
+  message ( FATAL_ERROR "Set environment variable CMAKE_MODULES and try again" )
+endif ( _MODULES )
+unset ( _MODULES CACHE )
+
+include ( FedemConfig )
+
+# Enable unit testing
+
+enable_testing ()
+set ( CTEST_OPTIONS --force-new-ctest-process --output-on-failure -O CTest.txt )
+add_custom_target ( check COMMAND ${CMAKE_CTEST_COMMAND} ${CTEST_OPTIONS} )
+
+include ( GTest ) # Using the google test framework for C++ unit tests
+
+if ( GTest_FOUND )
+  add_executable ( test_cmake test_gtest.C )
+  add_cpp_test ( test_cmake )
+else ( GTest_FOUND )
+  message ( FATAL_ERROR "The google test framework was not found" )
+endif ( GTest_FOUND )

--- a/test/test_gtest.C
+++ b/test/test_gtest.C
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2023 SAP SE
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// This file is part of FEDEM - https://openfedem.org
+////////////////////////////////////////////////////////////////////////////////
+
+#include <iostream>
+#include "gtest/gtest.h"
+
+
+TEST(TestCmake,Hello)
+{
+  std::cout <<"Hello, world"<< std::endl;
+  double a = 2.0;
+  double b = 3.5;
+  double c = a + b;
+  ASSERT_EQ(c,5.5);
+}


### PR DESCRIPTION
To avoid warning when run by github actions with the latest cmake version