### PR TITLE
Silence ifort deprecation warning

### DIFF
--- a/Modules/FedemConfig.cmake
+++ b/Modules/FedemConfig.cmake
@@ -41,7 +41,7 @@ endif ( FTENV_WARNINGS )
 
 set ( UNIX_GFORTRAN_COMPILER_FLAGS "-cpp -frecursive -fwhole-file ${GCC_FLAGS}" )
 set ( UNIX_IFORT_COMPILER_FLAGS    "-nologo -libs:dll -fpp -threads" )
-set ( WIN_IFORT_COMPILER_FLAGS     "/nologo /libs:dll /fpp /threads /guard:cf /GS" )
+set ( WIN_IFORT_COMPILER_FLAGS     "/nologo /libs:dll /fpp /threads /guard:cf /GS /Qdiag-disable:10448" )
 set ( WIN_C_COMPILER_FLAGS         "/Zc:wchar_t /guard:cf /GS /EHsc /MD" )
 
 if ( USE_INTEL_FORTRAN )


### PR DESCRIPTION
We'll do the recommended shift to the new LLVM-based compiler (ifx) later..