### PR TITLE
Enforce the C++17 language standard for all code

### DIFF
--- a/Modules/FedemConfig.cmake
+++ b/Modules/FedemConfig.cmake
@@ -73,7 +73,7 @@ if ( LINUX )
     set ( _CXX_FLAGS   ${UNIX_C_COMPILER_FLAGS} )
   else ( USE_INTEL_FORTRAN )
     # These flags apply for the GNU compilers only
-    set ( _CXX_FLAGS     "-std=c++14 ${UNIX_C_COMPILER_FLAGS}" )
+    set ( _CXX_FLAGS     "${UNIX_C_COMPILER_FLAGS}" )
     set ( _F_FLAGS_DEBUG "-g -fcheck=all" )
     set ( _C_FLAGS_DEBUG "-g" )
     set ( _C_FLAGS_COV   "--coverage" )
@@ -116,3 +116,7 @@ elseif ( NOT USE_INTEL_FORTRAN )
   set ( CMAKE_STATIC_LINKER_FLAGS_COVERAGE ${CMAKE_STATIC_LINKER_FLAGS_RELEASE} CACHE STRING "Coverage flags for linker" FORCE )
 
 endif ( WIN )
+
+# Enforce the C++17 language standard
+set ( CMAKE_CXX_STANDARD 17 )
+set ( CMAKE_CXX_STANDARD_REQUIRED ON )

--- a/Modules/GTest.cmake
+++ b/Modules/GTest.cmake
@@ -30,8 +30,6 @@ if ( GTest_FOUND )
   # Wrapper for gtest_add_tests
   function ( add_cpp_test TARGET )
     message ( STATUS "INFORMATION : Adding unit tests from ${TARGET}" )
-    # GoogleTest now requires the C++17 standard
-    set_property ( TARGET ${TARGET} PROPERTY CXX_STANDARD 17 )
     gtest_add_tests ( ${TARGET} "--srcdir=${CMAKE_CURRENT_SOURCE_DIR}" AUTO )
     if ( ${ARGC} GREATER 1 )
       target_link_libraries ( ${TARGET} ${ARGN} )


### PR DESCRIPTION
In particular, such that one can reduce scope of variables in if-blocks, like, e.g.

    if (int i = getValue(); i > 0)
      std::cout << i <<" is non-zero\n";

    // i is not defined here

instead of:

    int i = getValue();
    if (i > 0)
      std::cout << i <<" is non-zero";

    // i is still defined

Probably other things as well.